### PR TITLE
Fix resource save normalization

### DIFF
--- a/src/hooks/resource/useResourceDataFetch.tsx
+++ b/src/hooks/resource/useResourceDataFetch.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from 'react';
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
+import { normalizeSubstepTitle } from "@/utils/normalizeSubstepTitle";
 
 interface FetchOptions {
   stepId: number;
@@ -23,11 +24,12 @@ export function useResourceDataFetch({
   setIsLoading,
 }: FetchOptions) {
   const { toast } = useToast();
+  const normalizedSubstepTitle = normalizeSubstepTitle(stepId, substepTitle);
 
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
-      console.log(`Fetching data for: stepId=${stepId}, substep=${substepTitle}, type=${resourceType}`);
+      console.log(`Fetching data for: stepId=${stepId}, substep=${substepTitle}, normalized=${normalizedSubstepTitle}, type=${resourceType}`);
       
       try {
         // Check for session
@@ -48,7 +50,7 @@ export function useResourceDataFetch({
           .select('*')
           .eq('user_id', session.user.id)
           .eq('step_id', stepId)
-          .eq('substep_title', substepTitle)
+          .eq('substep_title', normalizedSubstepTitle)
           .eq('resource_type', resourceType);
           
         if (userResourceError) {
@@ -81,7 +83,7 @@ export function useResourceDataFetch({
           .from('entrepreneur_resources')
           .select('*')
           .eq('step_id', stepId)
-          .eq('substep_title', substepTitle)
+          .eq('substep_title', normalizedSubstepTitle)
           .eq('resource_type', resourceType)
           .limit(1);
           
@@ -129,5 +131,5 @@ export function useResourceDataFetch({
 
     fetchData();
     // eslint-disable-next-line
-  }, [stepId, substepTitle, resourceType]);
+  }, [stepId, substepTitle, normalizedSubstepTitle, resourceType]);
 }

--- a/src/hooks/resource/useResourceSave.tsx
+++ b/src/hooks/resource/useResourceSave.tsx
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import { useNavigate } from "react-router-dom";
 import { saveLastPath, saveResourceReturnPath } from "@/utils/navigationUtils";
+import { normalizeSubstepTitle } from "@/utils/normalizeSubstepTitle";
 
 interface SaveOptions {
   formData: any;
@@ -25,6 +26,7 @@ export function useResourceSave({
 }: SaveOptions) {
   const { toast } = useToast();
   const navigate = useNavigate();
+  const normalizedSubstepTitle = normalizeSubstepTitle(stepId, substepTitle);
   const lastSavedContentRef = useRef('');
   const toastShownRef = useRef(false);
   const saveTimeoutRef = useRef<any>(null);
@@ -189,7 +191,9 @@ export function useResourceSave({
           .from('user_resources')
           .update({
             content: formData,
-            updated_at: new Date().toISOString()
+            updated_at: new Date().toISOString(),
+            substep_title: normalizedSubstepTitle,
+            original_substep_title: substepTitle
           })
           .eq('id', resourceId)
           .select();
@@ -206,7 +210,7 @@ export function useResourceSave({
           .select('id')
           .eq('user_id', session.user.id)
           .eq('step_id', stepId)
-          .eq('substep_title', substepTitle)
+          .eq('substep_title', normalizedSubstepTitle)
           .eq('resource_type', resourceType)
           .maybeSingle();
           
@@ -217,7 +221,9 @@ export function useResourceSave({
             .from('user_resources')
             .update({
               content: formData,
-              updated_at: new Date().toISOString()
+              updated_at: new Date().toISOString(),
+              substep_title: normalizedSubstepTitle,
+              original_substep_title: substepTitle
             })
             .eq('id', existingResource.id)
             .select();
@@ -226,7 +232,8 @@ export function useResourceSave({
           const resourceData = {
             user_id: session.user.id,
             step_id: stepId,
-            substep_title: substepTitle,
+            substep_title: normalizedSubstepTitle,
+            original_substep_title: substepTitle,
             resource_type: resourceType,
             content: formData,
             created_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- normalize substep title inside `useResourceSave`
- store original and normalized titles in user resource records
- fetch resources using normalized substep titles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fff4eb9b0833282b594d71ddfc665